### PR TITLE
KC - add tab navigation and new match page example

### DIFF
--- a/Roomi/Roomi/Core/Home/HomeView.swift
+++ b/Roomi/Roomi/Core/Home/HomeView.swift
@@ -1,17 +1,90 @@
-//
-//  HomeView.swift
-//  Roomi
-//
-//  Created by Anderson Lee on 10/22/24.
-//
-
 import SwiftUI
 
 struct HomeView: View {
+    @EnvironmentObject var viewModel: AuthViewModel
+    @State private var selectedTab: Int = 1
+    @State private var showTabBar: Bool = false
+    
+    let tabs = [
+        (title: "Matches", image: "person.fill"),
+        (title: "Home", image: "house.fill"),
+        (title: "Profile", image: "gearshape.fill")
+    ]
+    
     var body: some View {
-        NavigationStack {
-            Text("Welcome to Roomi!")
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: backgroundColors(for: selectedTab)),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .edgesIgnoringSafeArea(.all)
+            
+            VStack {
+                if selectedTab == 0 {
+                    MatchesView()
+                } else if selectedTab == 1 {
+                    SearchView()
+                } else if selectedTab == 2 {
+                    ProfileView()
+                }
+                
+                Spacer()
+                
+                VStack(spacing: 0) {
+                    Divider()
+                    
+                    HStack {
+                        ForEach(0..<tabs.count, id: \.self) { index in
+                            Spacer()
+                            
+                            Button(action: {
+                                withAnimation {
+                                    selectedTab = index
+                                }
+                            }) {
+                                VStack {
+                                    Image(systemName: tabs[index].image)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: selectedTab == index ? 30 : 24, height: selectedTab == index ? 30 : 24)
+                                        .foregroundColor(.white)
+                                        .scaleEffect(selectedTab == index ? 1.1 : 1.0)
+                                        .animation(.spring(), value: selectedTab == index)
+                                    
+                                    Text(tabs[index].title)
+                                        .font(.caption2)
+                                        .foregroundColor(.white)
+                                }
+                            }
+                            .frame(maxWidth: selectedTab == index ? 80 : 50)
+                            .animation(.easeInOut, value: selectedTab == index)
+                            
+                            Spacer()
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 5)
+                }
+                .background(Color.clear)
+                .transition(.opacity)
+                .frame(height: 60)
+            }
         }
+    }
+    
+    func backgroundColors(for tab: Int) -> [Color] {
+        return [Color.blue, Color.purple]
+    }
+}
+
+extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xff) / 255,
+            green: Double((hex >> 08) & 0xff) / 255,
+            blue: Double((hex >> 00) & 0xff) / 255
+        )
     }
 }
 

--- a/Roomi/Roomi/Core/Matches/MatchesView.swift
+++ b/Roomi/Roomi/Core/Matches/MatchesView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct MatchesView: View {
+    @State private var selectedTab: MatchTab = .matches
+
+    enum MatchTab: String, CaseIterable {
+        case matches = "Matches"
+        case likes = "Likes"
+    }
+
+    let matchedProfiles = [
+        Profile(name: "Alex", age: 26, gender: "Male", location: "San Francisco, CA", image: "person.fill", bio: "Loves hiking and outdoor adventures."),
+        Profile(name: "Jordan", age: 29, gender: "Female", location: "Los Angeles, CA", image: "person.fill", bio: "Tech enthusiast and coffee lover."),
+        Profile(name: "Taylor", age: 24, gender: "Female", location: "New York, NY", image: "person.fill", bio: "Aspiring artist and foodie.")
+    ]
+
+    let likedProfiles = [
+        Profile(name: "Chris", age: 27, gender: "Male", location: "Austin, TX", image: "person.fill", bio: "Musician and part-time chef."),
+        Profile(name: "Morgan", age: 30, gender: "Female", location: "Seattle, WA", image: "person.fill", bio: "Entrepreneur with a passion for travel.")
+    ]
+
+    var displayedProfiles: [Profile] {
+        switch selectedTab {
+        case .matches:
+            return matchedProfiles
+        case .likes:
+            return likedProfiles
+        }
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                MatchTabPicker(selectedTab: $selectedTab)
+
+                ScrollView {
+                    VStack(spacing: 20) {
+                        ForEach(displayedProfiles) { profile in
+                            NavigationLink(destination: ProfileDetailView(profile: profile)) {
+                                ProfileCardView(profile: profile)
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: [Color(hex: 0x4A90E2), Color(hex: 0x9013FE)]),
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .edgesIgnoringSafeArea(.all)
+            )
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+struct MatchTabPicker: View {
+    @Binding var selectedTab: MatchesView.MatchTab
+
+    var body: some View {
+        Picker("", selection: $selectedTab) {
+            ForEach(MatchesView.MatchTab.allCases, id: \.self) { tab in
+                Text(tab.rawValue)
+                    .tag(tab)
+            }
+        }
+        .pickerStyle(SegmentedPickerStyle())
+        .padding()
+    }
+}
+
+#Preview {
+    MatchesView()
+}

--- a/Roomi/Roomi/Core/Matches/Profile.swift
+++ b/Roomi/Roomi/Core/Matches/Profile.swift
@@ -1,0 +1,19 @@
+//
+//  Profile.swift
+//  Roomi
+//
+//  Created by Khang Chung on 10/31/24.
+//
+
+import SwiftUI
+
+struct Profile: Identifiable {
+    let id = UUID()
+    let name: String
+    let age: Int
+    let gender: String
+    let location: String
+    let image: String
+    let bio: String
+}
+

--- a/Roomi/Roomi/Core/Matches/ProfileCardView.swift
+++ b/Roomi/Roomi/Core/Matches/ProfileCardView.swift
@@ -1,0 +1,51 @@
+//
+//  ProfileCardView.swift
+//  Roomi
+//
+//  Created by Khang Chung on 10/31/24.
+//
+
+import SwiftUI
+
+struct ProfileCardView: View {
+    let profile: Profile
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.white.opacity(0.15))
+                .frame(height: 200)
+                .overlay(
+                    VStack {
+                        ProfileImageView(image: profile.image)
+                        
+                        Text(profile.name)
+                            .font(.title2).bold()
+                            .foregroundColor(.white)
+                        
+                        Text("\(profile.age) years old")
+                            .foregroundColor(.white.opacity(0.7))
+                            .padding(.bottom, 10)
+                    }
+                )
+                .shadow(radius: 10)
+                .padding(.horizontal)
+        }
+    }
+}
+
+struct ProfileImageView: View {
+    let image: String
+    var size: CGFloat = 80
+
+    var body: some View {
+        Image(systemName: image)
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .padding()
+            .background(Color.white.opacity(0.15))
+            .clipShape(Circle())
+            .shadow(radius: 10)
+    }
+}

--- a/Roomi/Roomi/Core/Matches/ProfileDetailView.swift
+++ b/Roomi/Roomi/Core/Matches/ProfileDetailView.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+struct ProfileDetailView: View {
+    let profile: Profile
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: [Color(hex: 0x4A90E2), Color(hex: 0x9013FE)]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .edgesIgnoringSafeArea(.all)
+            
+            VStack(spacing: 25) {
+                Spacer().frame(height: 80)
+                
+                ProfileImageView(image: profile.image, size: 120)
+                
+                Text(profile.name)
+                    .font(.largeTitle).bold()
+                    .foregroundColor(.white)
+                
+                HStack(spacing: 20) {
+                    GenderBubble(gender: profile.gender)
+                    AgeBubble(age: profile.age)
+                }
+                
+                LocationBubble(location: profile.location)
+                
+                ProfileInfoBubble(title: "About Me", text: profile.bio)
+                
+                Spacer()
+            }
+            .padding()
+            
+            VStack {
+                HStack {
+                    Button(action: {
+                        presentationMode.wrappedValue.dismiss()
+                    }) {
+                        Image(systemName: "chevron.left")
+                            .foregroundColor(.white)
+                            .font(.title)
+                    }
+                    .padding(.leading, 16)
+                    
+                    Spacer()
+                    
+                    Text(profile.name)
+                        .font(.headline)
+                        .foregroundColor(.white)
+                    
+                    Spacer()
+                    
+                    Spacer().frame(width: 44)
+                }
+                .padding(.horizontal)
+                .frame(height: 60)
+                .background(Color.clear)
+                .overlay(
+                    Divider()
+                        .background(Color.white.opacity(0.3)),
+                    alignment: .bottom
+                )
+                
+                Spacer()
+            }
+        }
+        .navigationBarHidden(true)
+    }
+}
+
+
+
+
+struct GenderBubble: View {
+    let gender: String
+
+    var body: some View {
+        VStack {
+            Image(systemName: gender == "Male" ? "person.fill" : "person.fill.badge.plus")
+                .resizable()
+                .frame(width: 30, height: 30)
+                .foregroundColor(.white)
+            Text(gender)
+                .font(.headline)
+                .foregroundColor(.white)
+        }
+        .padding()
+        .frame(width: 100)
+        .background(Color.white.opacity(0.15))
+        .cornerRadius(15)
+    }
+}
+
+struct AgeBubble: View {
+    let age: Int
+
+    var body: some View {
+        VStack {
+            Text("\(age)")
+                .font(.largeTitle).bold()
+                .foregroundColor(.white)
+            Text("years old")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.7))
+        }
+        .padding()
+        .frame(width: 100)
+        .background(Color.white.opacity(0.15))
+        .cornerRadius(15)
+    }
+}
+
+struct LocationBubble: View {
+    let location: String
+
+    var body: some View {
+        HStack {
+            Image(systemName: "mappin.and.ellipse")
+                .foregroundColor(.white)
+                .padding(.trailing, 5)
+            
+            Text(location)
+                .font(.body)
+                .foregroundColor(.white)
+        }
+        .padding()
+        .background(Color.white.opacity(0.1))
+        .cornerRadius(15)
+        .padding(.horizontal, 16)
+    }
+}
+
+struct ProfileInfoBubble: View {
+    let title: String
+    let text: String
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Text(title)
+                .font(.headline)
+                .foregroundColor(.white.opacity(0.9))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+            Text(text)
+                .font(.body)
+                .foregroundColor(.white)
+                .padding()
+                .background(Color.white.opacity(0.1))
+                .cornerRadius(15)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+}

--- a/Roomi/Roomi/Core/Root/ContentView.swift
+++ b/Roomi/Roomi/Core/Root/ContentView.swift
@@ -13,22 +13,7 @@ struct ContentView: View {
     var body: some View {
         Group {
             if viewModel.userSession != nil {
-                TabView {
-                    HomeView()
-                        .tabItem {
-                            Label("Home", systemImage: "house")
-                        }
-                    
-                    SearchView()
-                        .tabItem {
-                            Label("Search", systemImage: "magnifyingglass")
-                        }
-                    
-                    ProfileView()
-                        .tabItem {
-                            Label("Profile", systemImage: "person.circle")
-                        }
-                }
+                HomeView()
             }
             else {
                 if viewModel.loginState == true {

--- a/Roomi/Roomi/Core/Search/View/SearchView.swift
+++ b/Roomi/Roomi/Core/Search/View/SearchView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SearchView: View {
-    @ObservedObject var viewModel = AuthViewModel()
+    @EnvironmentObject var viewModel: AuthViewModel
     var body: some View {
         NavigationView {
             List (viewModel.userList) { user in


### PR DESCRIPTION
- [x] - There is a tab navigation bar that is animated when switching tabs
- [x] - There is a match page
- [x] - The match page has matches and a tab for likes
- [x] - Users can click on their matches/likes to see profile

https://github.com/user-attachments/assets/5729c9ef-852a-4573-afcd-b2032bdbebb8

